### PR TITLE
Underpants was giving itself a wedgie

### DIFF
--- a/underpants.go
+++ b/underpants.go
@@ -268,8 +268,7 @@ func serveHttpProxy(d *disp, w http.ResponseWriter, r *http.Request) {
   br.Header.Add("Underpants-Email", url.QueryEscape(u.Email))
   br.Header.Add("Underpants-Name", url.QueryEscape(u.Name))
 
-  c := http.Client{}
-  bp, err := c.Do(br)
+  bp, err := http.DefaultTransport.RoundTrip(br)
   if err != nil {
     panic(err)
   }


### PR DESCRIPTION
So... if you made a request through underpants that hit a backend that issues a 302 HTTP redirect, the underpants request would follow that redirect.

If the redirect went to itself (the outer host), then underpants would follow the redirect back onto itself, omitting the user cookie.

Which would end up with a very confusing 200 OK on the client side where you get the Google oauth login page.

The fix is to make the underpants backend request not follow redirects.