### PR TITLE
Send the userCookie with the correct flags when first set

### DIFF
--- a/underpants.go
+++ b/underpants.go
@@ -489,10 +489,12 @@ func setup(c *conf, port int) (*http.ServeMux, error) {
     cache.Put(v, &u)
 
     http.SetCookie(w, &http.Cookie{
-      Name:   userCookieKey,
-      Value:  url.QueryEscape(v),
-      Path:   "/",
-      MaxAge: 3600,
+      Name:     userCookieKey,
+      Value:    url.QueryEscape(v),
+      Path:     "/",
+      MaxAge:   3600,
+      HttpOnly: true,
+      Secure:   d.config.HasCerts(),
     })
 
     p := back.Path


### PR DESCRIPTION
The `Secure` and `HTTPOnly` flags were correctly added [when the cookie's value was refreshed](https://github.com/kellegous/underpants/blob/d6927832cf36eb556a400774263e712ad450b860/underpants.go#L306), but not when it was first set.