### PR TITLE
Fix the domain check to only match subdomains of `c.Oauth.Domain`

### DIFF
--- a/underpants.go
+++ b/underpants.go
@@ -473,7 +473,7 @@ func setup(c *conf, port int) (*http.ServeMux, error) {
     }
 
     // this only happens when someone edits the auth url
-    if !strings.HasSuffix(u.Email, c.Oauth.Domain) {
+    if !strings.HasSuffix(u.Email, "@" + c.Oauth.Domain) {
       http.Error(w,
         http.StatusText(http.StatusForbidden),
         http.StatusForbidden)


### PR DESCRIPTION
Supposing `c.Oauth.Domain == "foobar.com"`, this would have allowed a user with an email of `"baz@notfoobar.com"`.