### PR TITLE
We have a `config` here, not a `disp`

### DIFF
--- a/underpants.go
+++ b/underpants.go
@@ -494,7 +494,7 @@ func setup(c *conf, port int) (*http.ServeMux, error) {
       Path:     "/",
       MaxAge:   3600,
       HttpOnly: true,
-      Secure:   d.config.HasCerts(),
+      Secure:   c.HasCerts(),
     })
 
     p := back.Path


### PR DESCRIPTION
Always make sure your code compiles before committing :/
This corrects 77ee14198c96b5a6f7e056aa3b7e52f6497401d0