### PR TITLE
Add group-based granular authorization for individual routes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ If your configuration can stomach it, enable `use-strict-security-headers` to
 get some extra peace of mind.  This will block clickjacking, disable downstream
 HTTP caching, and turn on `Strict-Transport-Security` if HTTPS.
 
+For more granular access control, you can configure groups and their membership
+in the JSON file.  Once groups are configured, routes will deny all users who
+are not a member of one of the authorized groups by default.  The special `*`
+group can be used to allow any authenticated user access to the route.  See
+`underpants.sample.groups.json` for a configuration sample.
+
 ## Running
 
 Just run it; it's an executable.

--- a/underpants.go
+++ b/underpants.go
@@ -73,6 +73,11 @@ type conf struct {
     Key string
   }
 
+  // A mapping of group names to lists of user email addresses that are members
+  // of that group.  If this section is present, then the default behaviour for
+  // a route is to deny all users not in a group on its allowed-groups list.
+  Groups map[string][]string
+
   // The mappings from hostname to backend server.
   Routes []struct {
 
@@ -84,6 +89,12 @@ type conf struct {
     // non-root (i.e. http://example.com/foo/bar/) URL, the path of the URL will be
     // discarded.
     To string
+
+    // A list of groups which may access this route.  If groups are configured,
+    // users who are not a member of one of these groups will be denied access.
+    // A special group, `*`, may be specified which allows any authenticated
+    // user.
+    AllowedGroups []string `json:"allowed-groups"`
   }
 }
 
@@ -91,6 +102,12 @@ type conf struct {
 // any certificates were included in the configuration.
 func (c *conf) HasCerts() bool {
   return len(c.Certs) > 0
+}
+
+// Used to determine if the instance is configured for more granular group-based access
+// control lists.
+func (c *conf) HasGroups() bool {
+  return len(c.Groups) > 0
 }
 
 // A convience method for getting the relevant scheme based on whether certificates were
@@ -196,6 +213,9 @@ type disp struct {
 
   // The OAuth configuration object needed for authentication.
   oauth *oauth.Config
+
+  // The groups which may access this backend.
+  groups []string
 }
 
 // Construct a URL to the oauth provider that with carry the provided URL as state
@@ -247,6 +267,22 @@ func urlFor(scheme, host string, r *http.Request) *url.URL {
   return &u
 }
 
+func userMemberOf(c *conf, u *user, groups []string) bool {
+  for _, group := range groups {
+    if group == "*" {
+      return true
+    }
+
+    for _, allowedUser := range c.Groups[group] {
+      if u.Email == allowedUser {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
 // Serve the response by proxying it to the backend represented by the disp object.
 func serveHttpProxy(d *disp, w http.ResponseWriter, r *http.Request) {
   u := userFrom(r, d.key)
@@ -255,6 +291,14 @@ func serveHttpProxy(d *disp, w http.ResponseWriter, r *http.Request) {
       d.AuthCodeUrl(urlFor(d.config.Scheme(), d.host, r)),
       http.StatusFound)
     return
+  }
+
+  if d.config.HasGroups() {
+    if !userMemberOf(d.config, u, d.groups) {
+      log.Printf("Denied %s access to %s", u.Email, d.host)
+      http.Error(w, "Forbidden: you are not a member of a group authorized to view this site.", http.StatusForbidden)
+      return
+    }
   }
 
   br, err := http.NewRequest(r.Method, urlFor(d.route.scheme, d.route.host, r).String(), r.Body)
@@ -426,6 +470,7 @@ func setup(c *conf, port int) (*http.ServeMux, error) {
       host:   host,
       key:    key,
       oauth:  oc,
+      groups: r.AllowedGroups,
     }))
   }
 

--- a/underpants.sample.groups.json
+++ b/underpants.sample.groups.json
@@ -1,0 +1,33 @@
+{
+  "host" : "underpants.company.com",
+  "oauth" : {
+    "domain"        : "company.com",
+    "client-id"     : "oauth-client-id",
+    "client-secret" : "oauth-client-secret"
+  },
+  "use-strict-security-headers": true,
+  "groups": {
+    "supersecret": [
+      "a@company.com",
+      "b@company.com"
+    ]
+  },
+  "certs" : [
+    {
+      "crt" : "/path/to/crt.pem",
+      "key" : "/path/to/key.pem"
+    }
+  ],
+  "routes" : [
+    {
+      "from"           : "public.company.com",
+      "to"             : "http://localhost:8080",
+      "allowed-groups" : ["*"]
+    },
+    {
+      "from"           : "sensitive.company.com",
+      "to"             : "http://localhost:8081",
+      "allowed-groups" : ["supersecret"]
+    },
+  ]
+}


### PR DESCRIPTION
This is helpful if you want to limit some sites to specific subgroups within the organization.  I'm not a huge fan of putting this into the config file, but I looked at trying to do it with Google Groups membership or something of the like and couldn't find any useful APIs.  If you know of a cleaner way to get some kind of group membership from Google directly rather than encoding it in the config file, I'm all ears.