### PR TITLE
Add/proxy/rewrite various headers when talking to the backends.

### DIFF
--- a/underpants.go
+++ b/underpants.go
@@ -267,6 +267,25 @@ func urlFor(scheme, host string, r *http.Request) *url.URL {
   return &u
 }
 
+// Rewrite `Location` headers to point at the external hostname of a service if
+// the downstream uses its internal name.
+func rewriteRedirects(headers *http.Header, external string, internal string) {
+  location := headers.Get("Location")
+  if location == "" {
+    return
+  }
+
+  location_url, err := url.Parse(location)
+  if err != nil {
+    return
+  }
+
+  if location_url.Host == internal {
+    location_url.Host = external
+    headers.Set("Location", location_url.String())
+  }
+}
+
 func userMemberOf(c *conf, u *user, groups []string) bool {
   for _, group := range groups {
     if group == "*" {
@@ -325,6 +344,7 @@ func serveHttpProxy(d *disp, w http.ResponseWriter, r *http.Request) {
   }
   defer bp.Body.Close()
 
+  rewriteRedirects(&bp.Header, d.host, d.route.host)
   copyHeaders(w.Header(), bp.Header)
   w.WriteHeader(bp.StatusCode)
   if _, err := io.Copy(w, bp.Body); err != nil {

--- a/underpants.go
+++ b/underpants.go
@@ -340,7 +340,8 @@ func serveHttpProxy(d *disp, w http.ResponseWriter, r *http.Request) {
 
   bp, err := http.DefaultTransport.RoundTrip(br)
   if err != nil {
-    panic(err)
+    http.Error(w, "failed to get valid response from internal service", 503)
+    return
   }
   defer bp.Body.Close()
 

--- a/underpants.go
+++ b/underpants.go
@@ -312,6 +312,9 @@ func serveHttpProxy(d *disp, w http.ResponseWriter, r *http.Request) {
 
   copyHeaders(br.Header, r.Header)
 
+  // Proxy the Host header so the downstream knows how to generate useful URLs
+  br.Host = r.Host
+
   // User information is passed to backends as headers.
   br.Header.Add("Underpants-Email", url.QueryEscape(u.Email))
   br.Header.Add("Underpants-Name", url.QueryEscape(u.Name))

--- a/underpants.go
+++ b/underpants.go
@@ -316,8 +316,8 @@ func serveHttpProxy(d *disp, w http.ResponseWriter, r *http.Request) {
   br.Host = r.Host
 
   // User information is passed to backends as headers.
-  br.Header.Add("Underpants-Email", url.QueryEscape(u.Email))
-  br.Header.Add("Underpants-Name", url.QueryEscape(u.Name))
+  br.Header.Set("Underpants-Email", url.QueryEscape(u.Email))
+  br.Header.Set("Underpants-Name", url.QueryEscape(u.Name))
 
   bp, err := http.DefaultTransport.RoundTrip(br)
   if err != nil {


### PR DESCRIPTION
These headers should help make sure that backend services are able to render appropriate URLs for the client.  The redirect rewrite is intended to mimic the default configuration of nginx's `proxy_redirect` setting. 

Also, using `Set` for the `Underpants-*` headers makes them a bit more reliable for user in single-signon authentication.
