### PR TITLE
Improve TLS configuration.

### DIFF
--- a/underpants.go
+++ b/underpants.go
@@ -671,6 +671,13 @@ func ListenAndServe(addr string, cfg *conf, m *http.ServeMux) error {
       TLSConfig: &tls.Config{
         NextProtos:   []string{"http/1.1"},
         Certificates: certs,
+		MinVersion: tls.VersionTLS10,
+		CipherSuites: []uint16 {
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		},
+		PreferServerCipherSuites: true,
       },
     }
 


### PR DESCRIPTION
This removes SSLv3 and sets an explicit cipher preference.  Since we're
aiming for internal usage, I've opted for a more secure list and
eschewed compatibility with some of the less relevant clients like IE on
XP.

Compile with Go 1.5 for best results; many lower-level things like
TLS_FALLBACK_SCSV were taken care of in the stdlib updates.

![screenshot from 2015-10-15 11 52 10](https://cloud.githubusercontent.com/assets/338853/10524207/47f5128c-7333-11e5-9fc3-530e96700e8a.png)
