### PR TITLE
Use new mux package for routing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 
 Suppose you are a Google Apps customer and suppose you want to restrict access to some web servers to just the folks in your organization. Like, for instance, if you're building your internal apps on AWS. Pain in the ass, right? So put underpants in between the world and your backends and you can use your Google credentials to get in.
 
-## Go 1.9
-
-Underpants will currently not work if built with Go 1.9 due to a [breaking change](https://go-review.googlesource.com/c/go/+/38194) in `net/http`. A fix is in the works.
-
 ## Installation
 
 ```


### PR DESCRIPTION
Go 1.9 introduced a breaking change in the way that http.ServeMux handles
host routes. As a result, underpants lost the ability to route on hosts
that included ports (i.e. protected:8080). This change removes the use
of http.ServeMux and uses a custom mux in the mux package to that underpants
works consistently reguardless of which version of Go it was compiled with.