### PR TITLE
Config changes for running behind a proxy

### DIFF
--- a/auth/google/google_test.go
+++ b/auth/google/google_test.go
@@ -17,7 +17,7 @@ func TestAuthURLWithoutDomain(t *testing.T) {
 				ClientID:     "client_id",
 				ClientSecret: "client_secret",
 			},
-			Host: "foo.com",
+			Host: "foo.com:9090",
 		},
 		Port: 9090,
 	}

--- a/auth/okta/okta_test.go
+++ b/auth/okta/okta_test.go
@@ -18,7 +18,7 @@ func TestAuthURL(t *testing.T) {
 				ClientSecret: "client_secret",
 				BaseURL:      "https://oktapreview.com",
 			},
-			Host: "foo.com",
+			Host: "foo.com:9090",
 		},
 		Port: 9090,
 	}

--- a/config/context.go
+++ b/config/context.go
@@ -24,11 +24,7 @@ type membership struct {
 
 // Host is the normalized host URLs to the hub.
 func (c *Context) Host() string {
-	switch c.Port {
-	case 80, 443:
-		return c.Info.Host
-	}
-	return fmt.Sprintf("%s:%d", c.Info.Host, c.Port)
+	return c.Info.Host
 }
 
 // ListenAddr is the address that should be passed to net.Listen.


### PR DESCRIPTION
First off this is a great project. At one point I was wrestling with [bitly's oauth proxy,](https://github.com/bitly/oauth2_proxy) which was design with a more 1:1 proxy:service use case in mind. I really appreciate the simple config file and from/to frontend/backend routing.

These modifications were needed to easily run this behind an AWS load balancer (doing SSL termination). These changes should in theory allow it to run behind any proxy.

Also, needed to support some of the config moving to ENV vars.

Changes:
- `use-https : true/false` config field to force https scheme. Allows SSL termination to happen on a proxy before underpants, but for underpants to still redirect to https urls.
- Remove concatenation of "Host" + "Port". "Host" now represents the name and port (if desired). Allows underpants to run on non standard (80 or 443) port behind another proxy listening on standard port.
- Add support for ENV VARs to override the oauth config. This allows underpants.json config to be under source control, without having to include the oauth id/secret.
